### PR TITLE
Trim brewfile

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,9 +1,4 @@
-tap "homebrew/bundle"
 tap "homebrew/cask"
-tap "homebrew/core"
-brew "ansible"
+
 brew "nvm"
-brew "composer"
-brew "mysql-utilities"
-brew "mysql@5.7"
 cask "docker"


### PR DESCRIPTION
This PR trims the `Brewfile` to only include `nvm` and `docker`, as MySQL and Composer are now handled in Docker containers, and Ansible isn't necessary to develop on the hub in Cloud Platform.