### PR TITLE
Update digital-hub reference to reflect repo name

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The Docker Compose scripts tie together the CMS and frontend components. To do t
 
 ```
   │
-  ├── digital-hub (this repository)
+  ├── prisoner-content-hub (this repository)
   ├── prisoner-content-hub-backend
   └── prisoner-content-hub-frontend
 ```


### PR DESCRIPTION
Now we've updated the name of this repo to `prisoner-content-hub`, this reference needs to be renamed