### PR TITLE
Add patches directory to enable composer to patch

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -36,6 +36,7 @@ services:
     volumes:
       - ../prisoner-content-hub-backend/composer.json:/var/www/html/composer.json
       - ../prisoner-content-hub-backend/composer.lock:/var/www/html/composer.lock
+      - ../prisoner-content-hub-backend/patches:/var/www/html/patches
       - ../prisoner-content-hub-backend/modules/custom:/var/www/html/modules/custom
       - ../prisoner-content-hub-backend/profiles:/var/www/html/profiles
       - ../prisoner-content-hub-backend/themes:/var/www/html/themes


### PR DESCRIPTION
This PR adds the patches directory to the set of mounts in `docker-compose`.

### Intent

This allows us to install and maintain Drupal patches from a Docker container.