### PR TITLE
Use namespace-specific nginx for non-production environments

### DIFF
--- a/helm_deploy/prisoner-content-hub-proxy/values.development.yaml
+++ b/helm_deploy/prisoner-content-hub-proxy/values.development.yaml
@@ -1,2 +1,4 @@
 ingress:
+  annotations:
+    kubernetes.io/ingress.class: prisoner-content-hub-development
   hostName: proxy-prisoner-content-hub-development.apps.live-1.cloud-platform.service.justice.gov.uk

--- a/helm_deploy/prisoner-content-hub-proxy/values.production.yaml
+++ b/helm_deploy/prisoner-content-hub-proxy/values.production.yaml
@@ -1,3 +1,5 @@
 ingress:
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
   hostName: proxy.content-hub.prisoner.service.justice.gov.uk
   certSecretName: prisoner-content-hub-proxy-certificate

--- a/helm_deploy/prisoner-content-hub-proxy/values.staging.yaml
+++ b/helm_deploy/prisoner-content-hub-proxy/values.staging.yaml
@@ -1,2 +1,4 @@
 ingress:
+  annotations:
+    kubernetes.io/ingress.class: prisoner-content-hub-staging
   hostName: proxy-prisoner-content-hub-staging.apps.live-1.cloud-platform.service.justice.gov.uk

--- a/helm_deploy/prisoner-content-hub-proxy/values.yaml
+++ b/helm_deploy/prisoner-content-hub-proxy/values.yaml
@@ -17,7 +17,6 @@ ingress:
   enabled: true  
   tlsEnabled: true  
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/rewrite-target: /$2
     nginx.ingress.kubernetes.io/enable-modsecurity: "true"
     nginx.ingress.kubernetes.io/modsecurity-snippet: |


### PR DESCRIPTION
For https://trello.com/c/9w8hYZJQ/1380-add-annotation-to-ingress-controllers.

This PR updates the kubernetes ingress annotation following https://mojdt.slack.com/archives/CH6D099DF/p1598372708002900.

This only applies to non-production environments initially. Once we're ready to roll it out across the board we should probably refactor this to remove the environment-specific annotations into something like:

```
{{- $namespace_name := .Release.Namespace }}
apiVersion: networking.k8s.io/v1beta1
kind: Ingress
metadata:

  ... removed for brevity

  {{- with .Values.ingress.annotations }}
  annotations:
    kubernetes.io/ingress.class: {{ $namespace_name }}
    {{- toYaml . | nindent 4 }}
  {{- end }}
```
