### PR TITLE
Revert ingress class to 'nginx'

### DIFF
--- a/helm_deploy/prisoner-content-hub-proxy/values.development.yaml
+++ b/helm_deploy/prisoner-content-hub-proxy/values.development.yaml
@@ -1,4 +1,4 @@
 ingress:
   annotations:
-    kubernetes.io/ingress.class: prisoner-content-hub-development
+    kubernetes.io/ingress.class: nginx
   hostName: proxy-prisoner-content-hub-development.apps.live-1.cloud-platform.service.justice.gov.uk

--- a/helm_deploy/prisoner-content-hub-proxy/values.staging.yaml
+++ b/helm_deploy/prisoner-content-hub-proxy/values.staging.yaml
@@ -1,4 +1,4 @@
 ingress:
   annotations:
-    kubernetes.io/ingress.class: prisoner-content-hub-staging
+    kubernetes.io/ingress.class: nginx
   hostName: proxy-prisoner-content-hub-staging.apps.live-1.cloud-platform.service.justice.gov.uk


### PR DESCRIPTION
Following the ingress configuration rollback in Cloud Platform, we need to revert our ingress class back to `nginx`.

See https://mojdt.slack.com/archives/C013XH7TFV3/p1601994943068200