### PR TITLE
chore: Make local frontend asset overrides more specific. 

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -21,6 +21,10 @@
 # If you've renamed or moved these, update or comment-out the relevant bits below
 version: "3"
 
+volumes: 
+  # Composer settings such as auth tokens for composer updates are stored in here
+  composer_settings: 
+
 services:
   hub-frontend:
     build:
@@ -28,7 +32,10 @@ services:
     volumes:
       - ../prisoner-content-hub-frontend/server:/home/node/app/server
       - ../prisoner-content-hub-frontend/test:/home/node/app/test
-      - ../prisoner-content-hub-frontend/assets:/home/node/app/assets
+      - ../prisoner-content-hub-frontend/assets/fonts:/home/node/app/assets/fonts
+      - ../prisoner-content-hub-frontend/assets/images:/home/node/app/assets/images
+      - ../prisoner-content-hub-frontend/assets/javascript:/home/node/app/assets/javascript
+      - ../prisoner-content-hub-frontend/assets/sass:/home/node/app/assets/sass
 
   drupal:
     build:
@@ -41,5 +48,40 @@ services:
       - ../prisoner-content-hub-backend/profiles:/var/www/html/profiles
       - ../prisoner-content-hub-backend/themes:/var/www/html/themes
       - ../prisoner-content-hub-backend/sites:/var/www/html/sites
+      - composer_settings:/var/www/.composer
 
+  drupal-admin:
+    build:
+      context: ../prisoner-content-hub-backend
+      target: base
+    depends_on:
+      - drupal-db
+      - hub-elasticsearch
+    env_file:
+      - drupal.env
+    volumes:
+      - ../prisoner-content-hub-backend/composer.json:/var/www/html/composer.json
+      - ../prisoner-content-hub-backend/composer.lock:/var/www/html/composer.lock
+      - ../prisoner-content-hub-backend/patches:/var/www/html/patches
+      - ../prisoner-content-hub-backend/modules/custom:/var/www/html/modules/custom
+      - ../prisoner-content-hub-backend/profiles:/var/www/html/profiles
+      - ../prisoner-content-hub-backend/themes:/var/www/html/themes
+      - ../prisoner-content-hub-backend/sites:/var/www/html/sites
 
+  drupal-test:
+    build:
+      context: ../prisoner-content-hub-backend
+      target: test
+    depends_on:
+      - drupal-db
+      - hub-elasticsearch
+    env_file:
+      - drupal.env
+    volumes:
+      - ../prisoner-content-hub-backend/composer.json:/var/www/html/composer.json
+      - ../prisoner-content-hub-backend/composer.lock:/var/www/html/composer.lock
+      - ../prisoner-content-hub-backend/patches:/var/www/html/patches
+      - ../prisoner-content-hub-backend/modules/custom:/var/www/html/modules/custom
+      - ../prisoner-content-hub-backend/profiles:/var/www/html/profiles
+      - ../prisoner-content-hub-backend/themes:/var/www/html/themes
+      - ../prisoner-content-hub-backend/sites:/var/www/html/sites

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -21,10 +21,6 @@
 # If you've renamed or moved these, update or comment-out the relevant bits below
 version: "3"
 
-volumes: 
-  # Composer settings such as auth tokens for composer updates are stored in here
-  composer_settings: 
-
 services:
   hub-frontend:
     build:
@@ -40,43 +36,6 @@ services:
   drupal:
     build:
       context: ../prisoner-content-hub-backend
-    volumes:
-      - ../prisoner-content-hub-backend/composer.json:/var/www/html/composer.json
-      - ../prisoner-content-hub-backend/composer.lock:/var/www/html/composer.lock
-      - ../prisoner-content-hub-backend/patches:/var/www/html/patches
-      - ../prisoner-content-hub-backend/modules/custom:/var/www/html/modules/custom
-      - ../prisoner-content-hub-backend/profiles:/var/www/html/profiles
-      - ../prisoner-content-hub-backend/themes:/var/www/html/themes
-      - ../prisoner-content-hub-backend/sites:/var/www/html/sites
-      - composer_settings:/var/www/.composer
-
-  drupal-admin:
-    build:
-      context: ../prisoner-content-hub-backend
-      target: base
-    depends_on:
-      - drupal-db
-      - hub-elasticsearch
-    env_file:
-      - drupal.env
-    volumes:
-      - ../prisoner-content-hub-backend/composer.json:/var/www/html/composer.json
-      - ../prisoner-content-hub-backend/composer.lock:/var/www/html/composer.lock
-      - ../prisoner-content-hub-backend/patches:/var/www/html/patches
-      - ../prisoner-content-hub-backend/modules/custom:/var/www/html/modules/custom
-      - ../prisoner-content-hub-backend/profiles:/var/www/html/profiles
-      - ../prisoner-content-hub-backend/themes:/var/www/html/themes
-      - ../prisoner-content-hub-backend/sites:/var/www/html/sites
-
-  drupal-test:
-    build:
-      context: ../prisoner-content-hub-backend
-      target: test
-    depends_on:
-      - drupal-db
-      - hub-elasticsearch
-    env_file:
-      - drupal.env
     volumes:
       - ../prisoner-content-hub-backend/composer.json:/var/www/html/composer.json
       - ../prisoner-content-hub-backend/composer.lock:/var/www/html/composer.lock


### PR DESCRIPTION
Enables local frontend dev out-of-the-box

### Context

> Does this issue have a Trello card?
Nope, this is a trivial dev fix that only affects local development 🤠.

> If this is an issue, do we have steps to reproduce?
1. Follow the prisoner-content-hub Readme to set up local dev with Docker.
2. Start the service
3. See there's no CSS 😱 

### Intent

> What changes are introduced by this PR that correspond to the above card?
This PR updates the local mounts for Docker Compose, so we're more specific. This means we don't override the generated styles in the container.


> Would this PR benefit from screenshots?
<img width="1392" alt="Screenshot 2021-01-21 at 10 14 26" src="https://user-images.githubusercontent.com/464482/105336713-7722e480-5bd1-11eb-9ee7-592907710bec.png">

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [x] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
