### PR TITLE
chore: Update SSH key to fix broken CI build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ jobs:
           command: cd nprrelay && make push-preview
       - add_ssh_keys:
           fingerprints:
-            - "0a:04:a1:27:17:3e:3d:8a:20:91:79:a1:9e:af:85:6c"
+            - "ee:34:9e:b9:c0:98:8b:47:02:1d:eb:74:de:92:2b:93"
       - run:
           name: Save build number (for deployment)
           command: |
@@ -107,7 +107,7 @@ jobs:
           command: cd nprrelay && make push
       - add_ssh_keys:
           fingerprints:
-            - "0a:04:a1:27:17:3e:3d:8a:20:91:79:a1:9e:af:85:6c"
+            - "ee:34:9e:b9:c0:98:8b:47:02:1d:eb:74:de:92:2b:93"
       - run:
           name: Create Git Tag
           command: |


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?
Nope, it's a tiny dev fix 🤠

### Intent

This PR resolves the [failing build](https://app.circleci.com/pipelines/github/ministryofjustice/prisoner-content-hub/732/workflows/78dd05f4-956d-4e51-8f6a-77aadb189b81/jobs/5125) (hopefully...) by updating the GitHub/CircleCI SSH key fingerprint to match a newly generated one.

<img width="1392" alt="Screenshot 2021-01-21 at 14 26 09" src="https://user-images.githubusercontent.com/464482/105365471-325d7480-5bf6-11eb-9b18-91f87ce4a369.png">

### Considerations

> Is there any additional information that would help when reviewing this PR?
The easiest way to check this is to merge the PR and see a successful deploy, rolling back if it doesn't work...

> Are there any steps required when merging/deploying this PR?

### Checklist

- [x] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
