### PR TITLE
Expose ports for MariaDB and ElasticSearch for local development

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
     volumes:
       - drupal_db_data:/var/lib/mysql
       - ./drupal-db/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
+    ports:
+      - 3306:3306
 
   drupal:
     # TODO: rename digital-hub-be to prisoner-content-hub-drupal
@@ -47,6 +49,8 @@ services:
         hard: -1
     volumes:
       - elasticsearch_data:/usr/share/elasticsearch/data
+    ports:
+      - 9200:9200
 
 volumes:
   drupal_db_data:


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/2Rg3lbdM/1894-get-e2e-tests-running-locally

### Intent

> What changes are introduced by this PR that correspond to the above card?

Expose `3306` for MariaDB and `9200` for ElasticSearch to allow for running the E2E tests locally

### Considerations

> Is there any additional information that would help when reviewing this PR?

- Exposing MariaDB allows for database clients to be connected when importing databases
- Exposing ElasticSearch allows for a local frontend to connect and query the database

### Checklist

- [x] This PR contains **only** changes related to the above card
- [x] Tests have been added/updated to cover the change
- [x] Documentation has been updated where appropriate
- [x] Tested in Development
