### PR TITLE
Set the whole repo to be mounted via volumes.

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -38,13 +38,7 @@ services:
       context: ../prisoner-content-hub-backend
       target: local
     volumes:
-      - ../prisoner-content-hub-backend/composer.json:/var/www/html/composer.json
-      - ../prisoner-content-hub-backend/composer.lock:/var/www/html/composer.lock
-      - ../prisoner-content-hub-backend/patches:/var/www/html/patches
-      - ../prisoner-content-hub-backend/modules/custom:/var/www/html/modules/custom
-      - ../prisoner-content-hub-backend/profiles:/var/www/html/profiles
-      - ../prisoner-content-hub-backend/themes:/var/www/html/themes
-      - ../prisoner-content-hub-backend/sites:/var/www/html/sites
+      - ../prisoner-content-hub-backend:/var/www/html
       - ../prisoner-content-hub-backend/php/xdebug.ini:/usr/local/etc/php/conf.d/xdebug.ini
 
 


### PR DESCRIPTION
### Context

https://trello.com/c/9syUElat/1898-unable-to-run-composer-inside-docker

### Intent

Fixes the issue of running composer from inside docker (when as the www-data user).
Why does this fix the issue?  Tbh I'm not 100% sure, have tried to work it out but feels now like a waste of time.  It might be the order of how things are created and mounted.  I know that `composer install` in the Dockerfile is run as root, but this is then chown to www-data.  However, for some reason the vendor directory still ends being owned root.  After this change it gets owned by www-data.

This fix appears to be related to this answer here: https://stackoverflow.com/a/56990338
But I don't think this quite fully explains it.

There's been a few discussions between myself and @spikeheap about making this change to `volumes` for other reasons.  Myself being in favour (as it means all the files inside the Docker can be accessed via an IDE).  @spikeheap wanted to keep mounts to only directories we know are being used, mainly to avoid data "sneaking" in from the host (e.g. via somekind of `.caches/` folder).  
I feel like now with this vendor directory permission issue (along with the others I previously had), we should just mount the entire directory, as it would avoid confusion and further issues.
This is pretty standard practise for Drupal projects.  I've never heard of a cache (or anything similar) causing issues from the host.  It's rare for composer to cause issues when being run from the host (although we should run from inside the container anyway as best practise).

### Considerations


### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
