### PR TITLE
Update Docker Compose configuration to run Cypress E2E tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-db_dump/
 .idea/**
 .idea
 .DS_Store
@@ -9,4 +8,4 @@ db_dump/
 .settings
 .cache
 *.env
-drupal-db/docker-entrypoint-initdb.d/*
+drupal-db/*

--- a/README.md
+++ b/README.md
@@ -82,14 +82,14 @@ docker-compose -f docker-compose.yml up -d
 
 ### Seeding the database
 
-When starting from a clean environment, you can seed the database automagically by placing scripts in [drupal-db/docker-entrypoint-initdb.d/](drupal-db/docker-entrypoint-initdb.d/).
+When starting from a clean environment, you can seed the database automagically by placing scripts in [drupal-db/](drupal-db/docker-entrypoint-initdb.d/).
 
-> Scripts in `drupal-db/docker-entrypoint-initdb.d/` will only be run when the database hasn't been initialised, so it won't overwrite an existing setup.
+> Scripts in `drupal-db/` will only be run when the database hasn't been initialised, so it won't overwrite an existing setup.
 
 As an example, you could create two files:
 
-1. `drupal-db/docker-entrypoint-initdb.d/01_hub_export-05-14-2020.sql`. This is a standard DB dump of one of our environments.
-2. `drupal-db/docker-entrypoint-initdb.d/02_update_hubdb_user_password.sql`. This could be something like:
+1. `drupal-db/01_hub_export-05-14-2020.sql`. This is a standard DB dump of one of our environments.
+2. `drupal-db/02_update_hubdb_user_password.sql`. This could be something like:
 
 ```sql
 USE hubdb;
@@ -108,6 +108,20 @@ The MariaDB and ElasticSearch services are backed by persistent volumes. These c
 ```
 docker-compose down --volumes
 ```
+
+## Running the E2E tests
+
+Spin up the backing services
+
+`FRONTEND_IMAGE_VERSION=latest BACKEND_IMAGE_VERSION=latest docker-compose -f docker-compose.yml -f docker-compose.e2e.yml up -d prisoner-content-hub-backend-db prisoner-content-hub-elasticsearch prisoner-content-hub-backend prisoner-content-hub-frontend`
+
+Launch the Cypress E2E tests
+
+`FRONTEND_IMAGE_VERSION=latest BACKEND_IMAGE_VERSION=latest docker-compose -f docker-compose.yml -f docker-compose.e2e.yml up cypress`
+
+Bring down the Docker-Compose and clear down volumes
+
+`FRONTEND_IMAGE_VERSION=latest BACKEND_IMAGE_VERSION=latest docker-compose -f docker-compose.yml -f docker-compose.e2e.yml down --volumes`
 
 ## Docker images
 

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -1,0 +1,19 @@
+version: "3"
+
+services:
+  cypress:
+    image: cypress/included:6.3.0
+    depends_on:
+      - prisoner-content-hub-frontend
+    working_dir: /test
+    volumes:
+      - ../prisoner-content-hub-frontend/cypress/:/test/cypress/
+      - ../prisoner-content-hub-frontend/cypress.json:/test/cypress.json
+    networks:
+      - prisoner_content_hub
+
+  prisoner-content-hub-backend:
+    image: "mojdigitalstudio/prisoner-content-hub-backend:${BACKEND_IMAGE_VERSION}"
+
+  prisoner-content-hub-frontend:
+    image: "mojdigitalstudio/prisoner-content-hub-frontend:${FRONTEND_IMAGE_VERSION}"

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,28 +1,28 @@
 #
 # This override file contains build contexts and local mount points
 # to enable local development.
-# 
+#
 # docker-compose.yml _AND_ docker-compose.override.yml are loaded by default
 # so you don't need to specify this file manually.
 #
 # To explicitly ignore these overrides (e.g. to test the setup with no local mounts)
 # use:
-# 
+#
 #   $ docker-compose -f docker-compose.yml <command>
 #
 # IMPORTANT ⚠️
-# 
+#
 # This override file assumes (and requires) that you have checked out the following
 # repositories alongside this one :
-# 
+#
 #   - prisoner-content-hub-backend
 #   - prisoner-content-hub-frontend
-#   
+#
 # If you've renamed or moved these, update or comment-out the relevant bits below
 version: "3"
 
 services:
-  hub-frontend:
+  prisoner-content-hub-frontend:
     build:
       context: ../prisoner-content-hub-frontend
     volumes:
@@ -33,12 +33,10 @@ services:
       - ../prisoner-content-hub-frontend/assets/javascript:/home/node/app/assets/javascript
       - ../prisoner-content-hub-frontend/assets/sass:/home/node/app/assets/sass
 
-  drupal:
+  prisoner-content-hub-backend:
     build:
       context: ../prisoner-content-hub-backend
       target: local
     volumes:
       - ../prisoner-content-hub-backend:/var/www/html
       - ../prisoner-content-hub-backend/php/xdebug.ini:/usr/local/etc/php/conf.d/xdebug.ini
-
-

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,48 +1,55 @@
 version: "3"
 
 services:
-  drupal-db:
+  prisoner-content-hub-backend-db:
     image: mariadb
     env_file:
       - drupal-db.env
     volumes:
-      - drupal_db_data:/var/lib/mysql
-      - ./drupal-db/docker-entrypoint-initdb.d:/docker-entrypoint-initdb.d
+      - drupal_db_data:/var/lib/mysql/
+      - ./drupal-db/:/docker-entrypoint-initdb.d/
     ports:
       - 3306:3306
+    networks:
+      - prisoner_content_hub
 
-  drupal:
-    # TODO: rename digital-hub-be to prisoner-content-hub-drupal
+  prisoner-content-hub-backend:
     image: mojdigitalstudio/prisoner-content-hub-backend
     depends_on:
-      - drupal-db
-      - hub-elasticsearch
+      - prisoner-content-hub-backend-db
+      - prisoner-content-hub-elasticsearch
     env_file:
       - drupal.env
     ports:
       - 11001:8080
+    networks:
+      - prisoner_content_hub
 
-  hub-frontend:
+  prisoner-content-hub-frontend:
     image: mojdigitalstudio/prisoner-content-hub-frontend
     depends_on:
-      - drupal
-      - hub-elasticsearch
+      - prisoner-content-hub-backend
+      - prisoner-content-hub-elasticsearch
     env_file:
       - hub-frontend.env
     ports:
-      - 10001:3000
+      - 3000:3000
+    networks:
+      prisoner_content_hub:
+        aliases:
+          - wayland.prisoner-content-hub.local
+          - berwyn.prisoner-content-hub.local
+          - cookhamwood.prisoner-content-hub.local
 
   # This container nameis referenced from Drupal DB config, so it should
   # match production
   # TODO: add init script to set Drupal ES connector from environment variable
-  hub-elasticsearch:
+  prisoner-content-hub-elasticsearch:
     image: docker.elastic.co/elasticsearch/elasticsearch:7.7.1
     environment:
       - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
       - "discovery.type=single-node"
       - xpack.security.enabled=false
-
-    # TODO: do we need these for local dev?
     ulimits:
       memlock:
         soft: -1
@@ -51,7 +58,12 @@ services:
       - elasticsearch_data:/usr/share/elasticsearch/data
     ports:
       - 9200:9200
+    networks:
+      - prisoner_content_hub
 
 volumes:
   drupal_db_data:
   elasticsearch_data:
+
+networks:
+  prisoner_content_hub:

--- a/drupal.env.sample
+++ b/drupal.env.sample
@@ -1,5 +1,5 @@
 # The following must match the container names & DB values in your docker-compose .env files or local setup
-HUB_DB_PORT_3306_TCP_ADDR=drupal-db
+HUB_DB_PORT_3306_TCP_ADDR=prisoner-content-hub-backend-db
 HUB_DB_ENV_MYSQL_DATABASE=hubdb
 HUB_DB_ENV_MYSQL_USER=hubdb_user
 HUB_DB_ENV_MYSQL_PASSWORD=S0MethingSecuRe
@@ -13,7 +13,7 @@ HUB_EXT_FILE_URL=http://localhost:11001/sites/default/files
 
 SERVER_PORT=8080
 ELASTICSEARCH_CLUSTER=elasticsearch
-ELASTICSEARCH_HOST=http://hub-elasticsearch:9200
+ELASTICSEARCH_HOST=http://prisoner-content-hub-elasticsearch:9200
 HASH_SALT=Sup3RS3cretH4sH
 
 PHP_MEMORY_LIMIT=256M

--- a/hub-frontend.env.sample
+++ b/hub-frontend.env.sample
@@ -1,10 +1,19 @@
 APP_TIMEOUT=60.0
 PORT=3000
-APP_NAME=HMP Dev
-MOCK_AUTH: 'true'
+APP_NAME=HMP Development
 
 # The following must match the container names in your docker-compose or local setup
-HUB_API_ENDPOINT=http://drupal:8080
-ELASTICSEARCH_ENDPOINT=http://hub-elasticsearch:9200
-BACKEND_URL=http://drupal:8080
+HUB_API_ENDPOINT=http://prisoner-content-hub-backend:8080
+ELASTICSEARCH_ENDPOINT=http://prisoner-content-hub-elasticsearch:9200
+FEEDBACK_URL=http://prisoner-content-hub-elasticsearch:9200/local-feedback/_doc
 
+ENABLE_PERSONALISATION=false
+ENABLE_REDIS_CACHE=false
+ENABLE_STACK_TRACES_ON_ERROR_PAGES=true
+
+AZURE_AD_CLIENT_ID='UNSET'
+AZURE_AD_CLIENT_SECRET='UNSET'
+PRISON_API_BASE_URL='http://foo.bar'
+HMPPS_AUTH_BASE_URL='http://foo.bar'
+HMPPS_AUTH_CLIENT_ID='UNSET'
+HMPPS_AUTH_CLIENT_SECRET='UNSET'


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/Y4TJ35U0/1908-run-cypress-tests-in-docker-compose

### Intent

> What changes are introduced by this PR that correspond to the above card?

- Add Docker-Compose configuration for E2E testing
- Update Docker-Compose to improve naming convention
- Update `sample.env` files
- Update documentation

### Considerations

> Is there any additional information that would help when reviewing this PR?

- Moved volume mount for the mounting the `prisoner-content-hub-backend-db` database
- Exposed port for `prisoner-content-hub-frontend` has been changed to be consistent with running locally (`10001 => 3000`)

### Checklist

- [x] This PR contains **only** changes related to the above card
- [x] Tests have been added/updated to cover the change
- [x] Documentation has been updated where appropriate
- [x] Tested in Development
