### PR TITLE
Update values.yaml

### DIFF
--- a/helm_deploy/prisoner-content-hub-proxy/values.yaml
+++ b/helm_deploy/prisoner-content-hub-proxy/values.yaml
@@ -46,6 +46,7 @@ ingress:
     cloudplatform-live1-2: "3.8.51.207/32"
     cloudplatform-live1-3: "35.177.252.54/32"
     moj-official: "51.149.250.0/24"
+    moj-official-globalprotect-alpha: "35.176.93.186/32"
     ark-data-center-1: "62.25.109.197/32"
     ark-data-center-2: "195.92.38.16/28"
     ark-data-center-3: "195.59.75.0/24"


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?
https://trello.com/c/Qgdi5nC7/224-access-the-content-hub-frontend-from-globalprotect-vpn

### Intent

This PR enables users on the GlobalProtect VPN to access the NPR proxy, hopefully preventing the dreaded "are you using the right VPN" conversation.

IP range taken from https://github.com/ministryofjustice/moj-ip-addresses/blob/main/moj-cidr-addresses.yml and checked against local GlobalProtect settings.

Partner of https://github.com/ministryofjustice/prisoner-content-hub-frontend/pull/315

### Checklist

- [x] This PR contains **only** changes related to the above card
