### PR TITLE
Add ingress annotations in preparation for cluster move

### DIFF
--- a/helm_deploy/prisoner-content-hub-proxy/values.development.yaml
+++ b/helm_deploy/prisoner-content-hub-proxy/values.development.yaml
@@ -1,4 +1,5 @@
 ingress:
   annotations:
     kubernetes.io/ingress.class: nginx
+    external-dns.alpha.kubernetes.io/set-identifier: prisoner-content-hub-proxy-prisoner-content-hub-development-blue
   hostName: proxy-prisoner-content-hub-development.apps.live-1.cloud-platform.service.justice.gov.uk

--- a/helm_deploy/prisoner-content-hub-proxy/values.production.yaml
+++ b/helm_deploy/prisoner-content-hub-proxy/values.production.yaml
@@ -1,5 +1,6 @@
 ingress:
   annotations:
     kubernetes.io/ingress.class: "nginx"
+    external-dns.alpha.kubernetes.io/set-identifier: prisoner-content-hub-proxy-prisoner-content-hub-production-blue
   hostName: proxy.content-hub.prisoner.service.justice.gov.uk
   certSecretName: prisoner-content-hub-proxy-certificate

--- a/helm_deploy/prisoner-content-hub-proxy/values.staging.yaml
+++ b/helm_deploy/prisoner-content-hub-proxy/values.staging.yaml
@@ -1,4 +1,5 @@
 ingress:
   annotations:
     kubernetes.io/ingress.class: nginx
+    external-dns.alpha.kubernetes.io/set-identifier: prisoner-content-hub-proxy-prisoner-content-hub-staging-blue
   hostName: proxy-prisoner-content-hub-staging.apps.live-1.cloud-platform.service.justice.gov.uk

--- a/helm_deploy/prisoner-content-hub-proxy/values.yaml
+++ b/helm_deploy/prisoner-content-hub-proxy/values.yaml
@@ -22,6 +22,7 @@ ingress:
   enabled: true
   tlsEnabled: true
   annotations:
+    external-dns.alpha.kubernetes.io/aws-weight: "100"
     nginx.ingress.kubernetes.io/rewrite-target: /$2
     nginx.ingress.kubernetes.io/server-snippet: |
       add_header X-Robots-Tag "noindex, nofollow, nosnippet, noarchive";


### PR DESCRIPTION
### Context

Adding new ingress annotations to prepare for move to new kubernetes cluster
https://trello.com/c/6oQHl9AH

### Intent

New ingresses added.

### Considerations

Need to ensure that we can still access radio after release

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
