### PR TITLE
Switching from old dockerhub org to quay.io.

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Bring down the Docker-Compose and clear down volumes
 
 ## Docker images
 
-Custom Docker images are hosted in the [MoJ Docker Hub organisation](https://hub.docker.com/u/mojdigitalstudio/).
+Custom Docker images are hosted in the [HMPPS Quay.io organisation](https://quay.io/organization/hmpps).
 
 # Contributing to the project
 

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -18,7 +18,7 @@ services:
       - prisoner_content_hub
 
   prisoner-content-hub-backend:
-    image: "mojdigitalstudio/prisoner-content-hub-backend:${BACKEND_IMAGE_VERSION}"
+    image: "quay.io/hmpps/prisoner-content-hub-backend:${BACKEND_IMAGE_VERSION}"
 
   prisoner-content-hub-frontend:
-    image: "mojdigitalstudio/prisoner-content-hub-frontend:${FRONTEND_IMAGE_VERSION}"
+    image: "quay.io/hmpps/prisoner-content-hub-frontend:${FRONTEND_IMAGE_VERSION}"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - prisoner_content_hub
 
   prisoner-content-hub-backend:
-    image: mojdigitalstudio/prisoner-content-hub-backend
+    image: quay.io/hmpps/prisoner-content-hub-backend
     depends_on:
       - prisoner-content-hub-backend-db
       - prisoner-content-hub-elasticsearch
@@ -26,7 +26,7 @@ services:
       - prisoner_content_hub
 
   prisoner-content-hub-frontend:
-    image: mojdigitalstudio/prisoner-content-hub-frontend
+    image: quay.io/hmpps/prisoner-content-hub-frontend
     depends_on:
       - prisoner-content-hub-backend
       - prisoner-content-hub-elasticsearch
@@ -67,7 +67,6 @@ services:
       - 6379:6379
     networks:
       - prisoner_content_hub
-
 
 volumes:
   drupal_db_data:

--- a/helm_deploy/prisoner-content-hub-proxy/values.yaml
+++ b/helm_deploy/prisoner-content-hub-proxy/values.yaml
@@ -4,7 +4,7 @@ fullnameOverride: ""
 tier: frontend
 
 image:
-  repository: mojdigitalstudio/prisoner-content-hub-nprrelay
+  repository: quay.io/hmpps/prisoner-content-hub-nprrelay
   pullPolicy: IfNotPresent
   tag: latest
 

--- a/nprrelay/Makefile
+++ b/nprrelay/Makefile
@@ -2,13 +2,13 @@ build:
 	docker build -t prisoner-content-hub-nprrelay .
 
 push:
-	@docker login -u $(DOCKER_USERNAME) -p $(DOCKER_PASSWORD)
-	docker tag prisoner-content-hub-nprrelay mojdigitalstudio/prisoner-content-hub-nprrelay:build-$(CIRCLE_BUILD_NUM)
-	docker tag prisoner-content-hub-nprrelay mojdigitalstudio/prisoner-content-hub-nprrelay:latest
-	docker push mojdigitalstudio/prisoner-content-hub-nprrelay:build-$(CIRCLE_BUILD_NUM)
-	docker push mojdigitalstudio/prisoner-content-hub-nprrelay:latest
+	@docker login -u="${QUAYIO_USERNAME}" -p="${QUAYIO_PASSWORD}" quay.io
+	docker tag prisoner-content-hub-nprrelay quay.io/hmpps/prisoner-content-hub-nprrelay:build-$(CIRCLE_BUILD_NUM)
+	docker tag prisoner-content-hub-nprrelay quay.io/hmpps/prisoner-content-hub-nprrelay:latest
+	docker push quay.io/hmpps/prisoner-content-hub-nprrelay:build-$(CIRCLE_BUILD_NUM)
+	docker push quay.io/hmpps/prisoner-content-hub-nprrelay:latest
 
 push-preview:
-	@docker login -u $(DOCKER_USERNAME) -p $(DOCKER_PASSWORD)
-	docker tag prisoner-content-hub-nprrelay mojdigitalstudio/prisoner-content-hub-nprrelay:preview
-	docker push mojdigitalstudio/prisoner-content-hub-nprrelay:preview
+	@docker login -u="${QUAYIO_USERNAME}" -p="${QUAYIO_PASSWORD}" quay.io
+	docker tag prisoner-content-hub-nprrelay quay.io/hmpps/prisoner-content-hub-nprrelay:preview
+	docker push quay.io/hmpps/prisoner-content-hub-nprrelay:preview


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

No this is a small change.

### Intent

We've been asked to switch away from using the mojdigitalstudio dockerhub account.  Instead, quay.io is the preferred platform for storing docker images.

See related PRs:

- https://github.com/ministryofjustice/prisoner-content-hub-backend/pull/404
- https://github.com/ministryofjustice/prisoner-content-hub-frontend/pull/491

### Considerations

> Is there any additional information that would help when reviewing this PR?

> Are there any steps required when merging/deploying this PR?

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
