### PR TITLE
Switch to new ingress controllers, with downtime.

### DIFF
--- a/helm_deploy/prisoner-content-hub-proxy/templates/ingress.yaml
+++ b/helm_deploy/prisoner-content-hub-proxy/templates/ingress.yaml
@@ -16,13 +16,13 @@ spec:
   - host: {{ .Values.ingress.hostName }}
     http:
       paths:
-        path: /{{ .Values.nprrelay.path }}(/|$)(.*)
-        pathType: Exact
-        backend:
-          service:
-            name: {{ include "prisoner-content-hub.fullname" . }}-{{ .Values.nprrelay.name }}
-            port:
-              number: 80
+        - path: /{{ .Values.nprrelay.path }}(/|$)(.*)
+          pathType: Exact
+          backend:
+            service:
+              name: {{ include "prisoner-content-hub.fullname" . }}-{{ .Values.nprrelay.name }}
+              port:
+                number: 80
   tls:
   - hosts:
     - {{ .Values.ingress.hostName }}

--- a/helm_deploy/prisoner-content-hub-proxy/templates/ingress.yaml
+++ b/helm_deploy/prisoner-content-hub-proxy/templates/ingress.yaml
@@ -11,6 +11,7 @@ metadata:
   {{- end }}
     nginx.ingress.kubernetes.io/whitelist-source-range: {{ include "app.joinListWithComma" .Values.ingress.allowed | quote }}
 spec:
+  ingressClassName: default
   rules:
   - host: {{ .Values.ingress.hostName }}
     http:

--- a/helm_deploy/prisoner-content-hub-proxy/templates/ingress.yaml
+++ b/helm_deploy/prisoner-content-hub-proxy/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- $fullName := include "prisoner-content-hub.fullname" . -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ $fullName }}
@@ -16,10 +16,13 @@ spec:
   - host: {{ .Values.ingress.hostName }}
     http:
       paths:
-      - backend:
-          serviceName: {{ include "prisoner-content-hub.fullname" . }}-{{ .Values.nprrelay.name }}
-          servicePort: http
         path: /{{ .Values.nprrelay.path }}(/|$)(.*)
+        pathType: Exact
+        backend:
+          service:
+            name: { { include "prisoner-content-hub.fullname" . } }-{{ .Values.nprrelay.name }}
+            port:
+              number: 80
   tls:
   - hosts:
     - {{ .Values.ingress.hostName }}

--- a/helm_deploy/prisoner-content-hub-proxy/templates/ingress.yaml
+++ b/helm_deploy/prisoner-content-hub-proxy/templates/ingress.yaml
@@ -20,7 +20,7 @@ spec:
         pathType: Exact
         backend:
           service:
-            name: { { include "prisoner-content-hub.fullname" . } }-{{ .Values.nprrelay.name }}
+            name: {{ include "prisoner-content-hub.fullname" . }}-{{ .Values.nprrelay.name }}
             port:
               number: 80
   tls:

--- a/helm_deploy/prisoner-content-hub-proxy/values.development.yaml
+++ b/helm_deploy/prisoner-content-hub-proxy/values.development.yaml
@@ -1,5 +1,4 @@
 ingress:
   annotations:
-    kubernetes.io/ingress.class: nginx
     external-dns.alpha.kubernetes.io/set-identifier: prisoner-content-hub-proxy-prisoner-content-hub-development-green
   hostName: proxy-prisoner-content-hub-development.apps.live.cloud-platform.service.justice.gov.uk

--- a/helm_deploy/prisoner-content-hub-proxy/values.local.yaml
+++ b/helm_deploy/prisoner-content-hub-proxy/values.local.yaml
@@ -2,5 +2,4 @@ ingress:
   tlsEnabled: false
   hostName: proxy.content-hub.local
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/rewrite-target: /$2

--- a/helm_deploy/prisoner-content-hub-proxy/values.production.yaml
+++ b/helm_deploy/prisoner-content-hub-proxy/values.production.yaml
@@ -1,6 +1,5 @@
 ingress:
   annotations:
-    kubernetes.io/ingress.class: "nginx"
     external-dns.alpha.kubernetes.io/set-identifier: prisoner-content-hub-proxy-prisoner-content-hub-production-green
   hostName: proxy.content-hub.prisoner.service.justice.gov.uk
   certSecretName: prisoner-content-hub-proxy-certificate

--- a/helm_deploy/prisoner-content-hub-proxy/values.staging.yaml
+++ b/helm_deploy/prisoner-content-hub-proxy/values.staging.yaml
@@ -1,5 +1,4 @@
 ingress:
   annotations:
-    kubernetes.io/ingress.class: nginx
     external-dns.alpha.kubernetes.io/set-identifier: prisoner-content-hub-proxy-prisoner-content-hub-staging-green
   hostName: proxy-prisoner-content-hub-staging.apps.live.cloud-platform.service.justice.gov.uk


### PR DESCRIPTION
### Context

> Does this issue have a Trello card?

https://trello.com/c/uFrdiYUP/1712-switch-to-new-ingress-controllers

### Intent

See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/networking/Switch-ingress-to-v1-ingress-controller.htm

### Considerations

This change will incur a small amount of downtime.  It should be deployed at the same time as https://github.com/ministryofjustice/prisoner-content-hub-frontend/pull/559, so that downtime is kept to a minimum. 

### Checklist

- [ ] This PR contains **only** changes related to the above card
- [ ] Tests have been added/updated to cover the change
- [ ] Documentation has been updated where appropriate
- [ ] Tested in Development
